### PR TITLE
Updating dependency upper bounds to support new versions of GHC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for data-elevator
 
+## 0.1.0.2 -- 2024-08-02
+
+* Added support for GHC versions 9.6, 9.8, and 9.10
+
+
 ## 0.1.0.0 -- 2022-07-31
 
 * First version

--- a/data-elevator.cabal
+++ b/data-elevator.cabal
@@ -1,8 +1,8 @@
 cabal-version:      2.4
 name:               data-elevator
-version:            0.1.0.0
+version:            0.1.0.2
 
-tested-with: GHC ==9.2.3 || ==9.4.1
+tested-with: GHC ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.2 || ==9.10.1
 
 -- A short (one-line) description of the package.
 synopsis: Coerce between unlifted boxed and lifted types.
@@ -44,7 +44,7 @@ library
 
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:
-    build-depends:    base >=4.16 && <4.18
+    build-depends:    base >=4.16 && <4.21
     hs-source-dirs:   src
     default-language: Haskell2010
 
@@ -56,6 +56,6 @@ test-suite data-elevator-test
     -- hs-source-dirs:
     main-is:          Main.hs
     hs-source-dirs:   test
-    build-depends:    base >=4.16 && <4.18
+    build-depends:    base >=4.16 && <4.21
                     , data-elevator
                     , hspec


### PR DESCRIPTION
I have updated the upper bounds of the `base` dependency to support compilation of GHC 9.6, GHC 9.8, and GHC 9.10. The project compiles with all supported versions on my local machine.

The package version has also been bumped to `1.0.0.2` in preparation for a new version upload to Hackage.